### PR TITLE
Fixed autolayout issues

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -76,7 +76,7 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
 
         // make sure the frame won't be negative values
         CGFloat y = MIN(maxY - self.parallaxHeaderMinimumReferenceSize.height, bounds.origin.y + self.collectionView.contentInset.top);
-        CGFloat height = MAX(0, -y + maxY);
+        CGFloat height = MAX(1, -y + maxY);
 
         currentAttribute.frame = (CGRect){
             frame.origin.x,


### PR DESCRIPTION
I changed line 79 from

``` objc
CGFloat height = MAX(0, -y + maxY);
```

to

``` objc
CGFloat height = MAX(1, -y + maxY);
```

to prevent an issue with autolayout:

```
2014-02-15 16:51:44.073 CSStickyHeaderFlowLayoutDemo[14879:70b] Unable to simultaneously satisfy constraints.
    Probably at least one of the constraints in the following list is one you don't want. Try this: (1) look at each constraint and try to figure out which you don't expect; (2) find the code that added the unwanted constraint or constraints and fix it. (Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints) 
(
    "<NSAutoresizingMaskLayoutConstraint:0x14a40e90 h=-&- v=-&- UIView:0x9ae7620.height == UICollectionViewCell:0x9a23ee0.height - 0.5>",
    "<NSLayoutConstraint:0x9d4aa10 'UIView-Encapsulated-Layout-Height' V:[UICollectionViewCell:0x9a23ee0(0)]>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x9d4aa10 'UIView-Encapsulated-Layout-Height' V:[UICollectionViewCell:0x9a23ee0(0)]>

Break on objc_exception_throw to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKit/UIView.h> may also be helpful.
```
