### PR TITLE
Add default to numberOfSectionsInCollectionView: method

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -62,7 +62,13 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
         visibleParallexHeader = YES;
     }
 
-    NSUInteger numberOfSections = [self.collectionView.dataSource numberOfSectionsInCollectionView:self.collectionView];
+
+    // This method may not be explicitly defined, default to 1
+    // https://developer.apple.com/library/ios/documentation/uikit/reference/UICollectionViewDataSource_protocol/Reference/Reference.html#jumpTo_6
+    NSUInteger numberOfSections = [self.collectionView.dataSource
+                                   respondsToSelector:@selector(numberOfSectionsInCollectionView:)]
+                                ? [self.collectionView.dataSource numberOfSectionsInCollectionView:self.collectionView]
+                                : 1;
 
     // Create the attributes for the Parallex header
     if (visibleParallexHeader && ! CGSizeEqualToSize(CGSizeZero, self.parallaxHeaderReferenceSize) && numberOfSections > 0) {


### PR DESCRIPTION
This branch will use the Apple specified default for `numberOfSectionsInCollectionView:` when not explicitly defined on the datasource. See: https://developer.apple.com/library/ios/documentation/uikit/reference/UICollectionViewDataSource_protocol/Reference/Reference.html#//apple_ref/occ/intfm/UICollectionViewDataSource/numberOfSectionsInCollectionView:
- [x] Check for existence of `numberOfSectionsInCollectionView:` on collection view datasource
- [x] Use default specified by Apple docs if not found
- [x] Ready for review
