### PR TITLE
Fix CollectionView zIndex issue when cells travel between sections

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -66,7 +66,7 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
         }
 
         // For iOS 7.0, the cell zIndex should be above sticky section header
-        attributes.zIndex = 1;
+        attributes.transform3D = CATransform3DMakeTranslation(0,0,1);
     }];
 
     // when the visible rect is at top of the screen, make sure we see
@@ -108,14 +108,14 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
         currentAttribute.progressiveness = progressiveness;
 
         // if zIndex < 0 would prevents tap from recognized right under navigation bar
-        currentAttribute.zIndex = 0;
+        currentAttribute.transform3D = CATransform3DMakeTranslation(0,0,0);
 
         // When parallaxHeaderAlwaysOnTop is enabled, we will check when we should update the y position
         if (self.parallaxHeaderAlwaysOnTop && height <= self.parallaxHeaderMinimumReferenceSize.height) {
             CGFloat insetTop = self.collectionView.contentInset.top;
             // Always stick to top but under the nav bar
             y = self.collectionView.contentOffset.y + insetTop;
-            currentAttribute.zIndex = 2000;
+            currentAttribute.transform3D = CATransform3DMakeTranslation(0,0,2000);
         }
 
         currentAttribute.frame = (CGRect){
@@ -181,7 +181,7 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
 - (void)updateHeaderAttributes:(UICollectionViewLayoutAttributes *)attributes lastCellAttributes:(UICollectionViewLayoutAttributes *)lastCellAttributes
 {
     CGRect currentBounds = self.collectionView.bounds;
-    attributes.zIndex = 1024;
+    attributes.transform3D = CATransform3DMakeTranslation(0,0,1024);
     attributes.hidden = NO;
 
     CGPoint origin = attributes.frame.origin;


### PR DESCRIPTION
UICollectionView doesn't handle zIndex very well during transitions. It caused some of cells to be shown above sticky header when these cells moved from one section to another.

http://stackoverflow.com/questions/12659301/uicollectionview-setlayoutanimated-not-preserving-zindex
