### PR TITLE
Fix cell positioning when using Size Classes

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -52,12 +52,18 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
 
     [allItems enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         UICollectionViewLayoutAttributes *attributes = obj;
-
+        
+        NSIndexPath *indexPath = [(UICollectionViewLayoutAttributes *)obj indexPath];
+        
         CGRect frame = attributes.frame;
         frame.origin.y += self.parallaxHeaderReferenceSize.height;
+        
+        if (indexPath.row == 0) {
+            frame.origin.x = 0.0;
+        }
+        
         attributes.frame = frame;
-
-        NSIndexPath *indexPath = [(UICollectionViewLayoutAttributes *)obj indexPath];
+        
         if ([[obj representedElementKind] isEqualToString:UICollectionElementKindSectionHeader]) {
             [headers setObject:obj forKey:@(indexPath.section)];
         } else if ([[obj representedElementKind] isEqualToString:UICollectionElementKindSectionFooter]) {


### PR DESCRIPTION
When a project is using Size Classes in interface builder, I've found that the collection view cells are not positioned correctly. Instead, they are shifted to the right and are therefore not completely visible on screen. I've found a workaround that fixes the cell positioning when the collection view will have one cell per row (similar to the UITableView layout). I'm not sure how this would affect other parts of the flow layout, however. Perhaps you could shed some light on this issue. Thanks!