### PR TITLE
Added possibility to set a custom size for each UICollectionViewCell.

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.h
+++ b/Classes/CSStickyHeaderFlowLayout.h
@@ -10,8 +10,17 @@
 
 extern NSString *const CSStickyHeaderParallaxHeader;
 
+@protocol CSStickyHeaderFlowLayoutDelegate <NSObject>
+
+@optional
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
+
+@end
+
+
 @interface CSStickyHeaderFlowLayout : UICollectionViewFlowLayout
 
+@property (nonatomic, weak) id<CSStickyHeaderFlowLayoutDelegate> delegate;
 @property (nonatomic) CGSize parallaxHeaderReferenceSize;
 @property (nonatomic) CGSize parallaxHeaderMinimumReferenceSize;
 @property (nonatomic) BOOL parallaxHeaderAlwaysOnTop;

--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -171,6 +171,14 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
     return attributes;
 }
 
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+   if([self.delegate respondsToSelector:@selector(collectionView:layout:sizeForItemAtIndexPath:)]) {
+      return [self.delegate collectionView:collectionView layout:collectionViewLayout sizeForItemAtIndexPath:indexPath];
+   } else {
+      return [self itemSize];
+   }
+}
+
 - (CGSize)collectionViewContentSize {
     CGSize size = [super collectionViewContentSize];
     size.height += self.parallaxHeaderReferenceSize.height;


### PR DESCRIPTION
I implemented the -collectionView:layout:sizeForItemAtIndexPath: method to have the possibility to to use different sizes for each item in the collection view. Therefore I have added a CSStickyHeaderFlowLayoutDelegate protocol to receive the layout sizes from the user.