### PR TITLE
CSStickyHeaderFlowLayoutAttributes confirms NSCopying protocol

### DIFF
--- a/Classes/CSStickyHeaderFlowLayoutAttributes.m
+++ b/Classes/CSStickyHeaderFlowLayoutAttributes.m
@@ -10,4 +10,10 @@
 
 @implementation CSStickyHeaderFlowLayoutAttributes
 
+- (id)copyWithZone:(NSZone *)zone {
+  typeof(self) copy = [super copyWithZone:zone];
+  copy.progressiveness = self.progressiveness;
+  return copy;
+}
+
 @end


### PR DESCRIPTION
Sometimes attributes are copied. So -copyWithZone: is implemented in CSStickyHeaderFlowLayoutAttributes to prevent loosing progressiveness.