### PR TITLE
Fix crash when dragging a cell over a sticky header

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -9,7 +9,11 @@
 #import "CSStickyHeaderFlowLayout.h"
 #import "CSStickyHeaderFlowLayoutAttributes.h"
 
+
 NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
+
+static const NSInteger kHeaderZIndex = 1024;
+
 
 @implementation CSStickyHeaderFlowLayout
 
@@ -58,13 +62,14 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
         attributes.frame = frame;
 
         NSIndexPath *indexPath = [(UICollectionViewLayoutAttributes *)obj indexPath];
-        if ([[obj representedElementKind] isEqualToString:UICollectionElementKindSectionHeader]) {
+        BOOL isHeader = [[obj representedElementKind] isEqualToString:UICollectionElementKindSectionHeader];
+        BOOL isFooter = [[obj representedElementKind] isEqualToString:UICollectionElementKindSectionFooter];
+
+        if (isHeader) {
             [headers setObject:obj forKey:@(indexPath.section)];
-        } else if ([[obj representedElementKind] isEqualToString:UICollectionElementKindSectionFooter]) {
+        } else if (isFooter) {
             // Not implemeneted
         } else {
-            NSIndexPath *indexPath = [(UICollectionViewLayoutAttributes *)obj indexPath];
-
             UICollectionViewLayoutAttributes *currentAttribute = [lastCells objectForKey:@(indexPath.section)];
 
             // Get the bottom most cell of that section
@@ -77,8 +82,12 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
             }
         }
 
-        // For iOS 7.0, the cell zIndex should be above sticky section header
-        attributes.zIndex = 1;
+        if (isHeader) {
+            attributes.zIndex = kHeaderZIndex;
+        } else {
+            // For iOS 7.0, the cell zIndex should be above sticky section header
+            attributes.zIndex = 1;
+        }
     }];
 
     // when the visible rect is at top of the screen, make sure we see
@@ -204,7 +213,7 @@ NSString *const CSStickyHeaderParallaxHeader = @"CSStickyHeaderParallexHeader";
 - (void)updateHeaderAttributes:(UICollectionViewLayoutAttributes *)attributes lastCellAttributes:(UICollectionViewLayoutAttributes *)lastCellAttributes
 {
     CGRect currentBounds = self.collectionView.bounds;
-    attributes.zIndex = 1024;
+    attributes.zIndex = kHeaderZIndex;
     attributes.hidden = NO;
 
     CGPoint origin = attributes.frame.origin;


### PR DESCRIPTION
Hi @jamztang,

Thanks for the library! :gift_heart:

I've just started using it and had a crash in a sticky header collection view when dragging a cell over a header. I fixed it by setting the default `zIndex` when element is a header. See if my fix makes sense.

The crash:

    Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'layout attributes for supplementary item at index path (<NSIndexPath: 0xc000000000000016> {length = 2, path = 0 - 0}) changed from <MyClassLayoutAttributes: 0x7f8c9c847590> index path: (<NSIndexPath: 0xc000000000000016> {length = 2, path = 0 - 0}); element kind: (UICollectionElementKindSectionHeader); frame = (0 0; 375 30); zIndex = 1024;  to <MyClassLayoutAttributes: 0x7f8c9ca7e6c0> index path: (<NSIndexPath: 0xc000000000000016> {length = 2, path = 0 - 0}); element kind: (UICollectionElementKindSectionHeader); frame = (0 0; 375 30); zIndex = 1;  without invalidating the layout'