### PR TITLE
Updating :path in Podfile to point to the podspec directory instead of the podspec file

### DIFF
--- a/Project/Podfile
+++ b/Project/Podfile
@@ -1,2 +1,2 @@
 platform :ios, '7.0'
-pod "CSStickyHeaderFlowLayout", :path => "../CSStickyHeaderFlowLayout.podspec"
+pod "CSStickyHeaderFlowLayout", :path => "../"


### PR DESCRIPTION
Fixes issue #83 

The :path in the Podfile for the example project currently points the podspec file instead of the podspec directory. Changing the :path to point to the directory of the podspec allows 'pod install' to be run on the example project in cocoapods 0.37.2. 