### PR TITLE
Don't show section headers whose size is zero

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -151,11 +151,13 @@ static const NSInteger kHeaderZIndex = 1024;
                 header = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
                                                               atIndexPath:[NSIndexPath indexPathForItem:0 inSection:indexPath.section]];
 
-                if (header) {
+                if (!CGSizeEqualToSize(CGSizeZero, header.frame.size)) {
                     [allItems addObject:header];
                 }
             }
-            [self updateHeaderAttributes:header lastCellAttributes:lastCells[indexPathKey]];
+            if (!CGSizeEqualToSize(CGSizeZero, header.frame.size)) {
+                [self updateHeaderAttributes:header lastCellAttributes:lastCells[indexPathKey]];
+            }
         }];
     }
 


### PR DESCRIPTION
## Steps to Reproduce the Bug

You can try it in `CSGrowHeaderViewController`.

1. Set section header's `clipsToBounds` to `NO`
2. Set the layout's `headerReferenceSize` to `CGSizeZero`.
3. Set the layout's `disableStickyHeaders` to `NO`
4. Build & run the demo app

## Expected Result

Section headers won't appear on the screen.

## Actual Result

Section headers' text appears.

## How to Fix It

CollectionView automatically removes headers whose size is "zero":

* Headers whose height is zero for `UICollectionViewScrollDirectionVertical`
* Headers whose width is zero for `UICollectionViewScrollDirectionHorizontal`.

A quick and dirty fix is to set the `clipsToBounds` property of section header to `YES`. However, it confuses the clients.

Here's a better solution. The following code doesn't exclude this kinds of headers.

``` obj-c
if (header) {
    [allItems addObject:header];
}
```

Instead, it should be:

``` obj-c
if (!CGSizeEqualToSize(CGSizeZero, header.frame.size)) {
    [allItems addObject:header];
}
```

**NOTE**: The size of a header will be set to `CGSizeZero` if the header shouldn't appear, so we only compare the size with `CGSizeZero`.

Also, do not update update header attributes if size is zero.

``` obj-c
if (!CGSizeEqualToSize(CGSizeZero, header.frame.size)) {
    [self updateHeaderAttributes:header lastCellAttributes:lastCells[indexPathKey]];
}
```

Cheers!
