### PR TITLE
Update CSStickyHeaderFlowLayout.m

### DIFF
--- a/Classes/CSStickyHeaderFlowLayout.m
+++ b/Classes/CSStickyHeaderFlowLayout.m
@@ -173,7 +173,7 @@ static const NSInteger kHeaderZIndex = 1024;
 }
 
 - (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
-    UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:indexPath];
+    UICollectionViewLayoutAttributes *attributes = [super layoutAttributesForItemAtIndexPath:indexPath].copy;
     CGRect frame = attributes.frame;
     frame.origin.y += self.parallaxHeaderReferenceSize.height;
     attributes.frame = frame;


### PR DESCRIPTION
Fixing warning: subclass is modifying attributes returned by UICollectionViewFlowLayout without copying them